### PR TITLE
changed shebang line acc. to standards

### DIFF
--- a/PreProcessing/preprocessing.py
+++ b/PreProcessing/preprocessing.py
@@ -1,4 +1,4 @@
-#!python
+#!/usr/bin/env python3
 # coding=utf-8
 
 # Imports


### PR DESCRIPTION
Nothing major, changed the shebang line to [fit](https://stackoverflow.com/questions/5709616/whats-the-difference-between-these-two-python-shebangs) [the](https://stackoverflow.com/questions/2429511/why-do-people-write-the-usr-bin-env-python-shebang-on-the-first-line-of-a-pyt) [standards](https://docs.python.org/3/tutorial/appendix.html#executable-python-scripts).