### PR TITLE
added method to remove silent chunks

### DIFF
--- a/PreProcessing/preprocess_chunk_img.py
+++ b/PreProcessing/preprocess_chunk_img.py
@@ -145,10 +145,25 @@ def standardize_and_plot(sampling_rate, file_path_image):
                 os.chdir(work_dir)
 
 
+def remove_silent_chunk(output_audio_folder):
+    '''Remove audio chunks with loudness (dB) < -80.0'''
+    for dirs, subdirs, files in os.walk(output_audio_folder):
+        for file in files:
+            if file.endswith(('.wav', '.WAV')):
+                f_n = os.path.join(dirs, file)
+
+                f = AudioSegment.from_wav(f_n)
+
+                if f.dBFS < -80.0:
+                    os.remove(f_n)
+                    logger.info(f"Removed audio chunk: {f_n}")
+
+
 def main(args):
     sampling_rate = args.resampling
     file_path_audio = args.classpath
     chunkSize = args.chunks
+    silent_chunks_delete = args.silent
 
     no_of_files = len(os.listdir('.'))
 
@@ -186,6 +201,9 @@ def main(args):
 
     logger.info(f"Starting to load {no_of_files} data files in the directory")
 
+    if silent_chunks_delete:
+        remove_silent_chunk(output_audio_folder)
+
     standardize_and_plot(sampling_rate, file_path_image)
 
 
@@ -211,6 +229,12 @@ if __name__ == '__main__':
         type=int,
         default=3,
         help='Chunk Size for each sample to be divided to')
+    parser.add_argument(
+        '-m',
+        "--silent",
+        type=bool,
+        default=False,
+        help='Remove silent (dB<-80) audio chunks from PreProcesses_audio')
 
     args = parser.parse_args()
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ resample all the audio files to a specific sampling frequency.
   - This has been implemented in [preprocessing.py](https://github.com/axiom-data-science/OrcaCNN/blob/master/PreProcessing/preprocessing.py)
 - Removing all the dead samples (negligible frequency)(if any) from the
 dataset.
-  - The `make_chunks()` method takes care of this by dividing into fixed-size chunks of size `chunkSize` specified by `-s` argument.
+  - The `make_chunks()` method takes care of this by dividing into fixed-size chunks of size `chunkSize` specified by `-s` argument. Also, by specifying the `-m` flag as `True`, we can delete audio chunks with `db < -80`.
 - Denoising: The [Spectral-Subtraction](https://doi.org/10.1109/TASSP.1979.1163209) method can be used to reduce background
 noise. This method is based on spectral averaging and residual
 noise reduction, widely used for enhancement of noisy speech
@@ -117,7 +117,8 @@ Constant Q-Transform(CQT) and Constant Wavelet Transform (CWT).
 To put all the audio samples (.wav) in a standard format as described above, assuming all the [dependencies](https://github.com/axiom-data-science/OrcaCNN/blob/master/requirements.txt) are installed, simply run
 
 ```
-python PreProcessing/preprocess_chunk_img.py [-h] -c CLASSPATH [-r RESAMPLING] [-s CHUNKS]
+preprocess_chunk_img.py [-h] -c CLASSPATH [-r RESAMPLING] [-s CHUNKS] [-m SILENT]
+
 ```
 which will produce two folders:
 - `PreProcessed_audio` with all the audio chunks of size `CHUNKS` and,


### PR DESCRIPTION
To fasten up the whole process, I tried to remove those audio chunks which were below a threshold defined by [dbFS](https://github.com/jiaaro/pydub/blob/master/API.markdown#audiosegmentdbfs) < -80. 
The threshold was chosen as it worked well removing silent chunks as can be seen below. However, there were some files which were way below the threshold and were also silent, but this method does not remove them.

Also, the time taken for the run is similar to other calls, perhaps even faster.

1) File: `Field Recordings NGOS_2013 field acoustic recordings_2013-10-07 KW Acoustics_131007_0033_0000.wav`  with dBFS: `-82.54464225782733`

![Field Recordings NGOS_2013 field acoustic recordings_2013-10-07 KW Acoustics_131007_0033_0000_0000](https://user-images.githubusercontent.com/19359908/59384076-fb1eb480-8d7e-11e9-8edf-3fe14b6c68a9.png)

2)  File: `Field Recordings NGOS_2013 field acoustic recordings_2013-10-07 KW Acoustics_131007_0033_0018.wav`  with dBFS: ` -85.61855849317469`

![Field Recordings NGOS_2013 field acoustic recordings_2013-10-07 KW Acoustics_131007_0033_0018_0000](https://user-images.githubusercontent.com/19359908/59384158-2ef9da00-8d7f-11e9-854c-06b52020d0a1.png)

Files which cannot be removed :

3)  File: `Field Recordings NGOS_2008 field acoustic recordings_20081002 PWS AI AE_1005_0025_0000.wav`  with dBFS: ` -29.54834569817469`

![Field Recordings NGOS_2008 field acoustic recordings_20081002 PWS AI AE_1005_0025_0000](https://user-images.githubusercontent.com/19359908/59384374-a92a5e80-8d7f-11e9-983a-161948910521.png)

