### PR TITLE
rm deprecated predict_classes attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ To help in prediction, 4 ML models exist inside the `app/models` directory.
 
 #### Ubuntu 20.04
 
-Simply running the bash script `run.sh` will get everything running using [BuildKit](https://docs.docker.com/develop/develop-images/build_enhancements/)
+Simply executing the bash script `run.sh` will get everything running using [BuildKit](https://docs.docker.com/develop/develop-images/build_enhancements/) at `localhost:80`.
 
 ```
 sudo bash run.sh

--- a/app/Detection/orcacnn_detection.py
+++ b/app/Detection/orcacnn_detection.py
@@ -6,14 +6,14 @@ import os
 import argparse
 import logging
 import logging.config
-from keras import optimizers
-from keras.preprocessing.image import ImageDataGenerator
-from keras.layers import Dropout, Flatten, Dense, Activation
-from keras.callbacks import ReduceLROnPlateau, ModelCheckpoint
-from keras.models import Sequential
-from keras.layers import Conv2D
-from keras.layers import Activation, Dropout, Flatten, Dense
-from keras import backend as K
+from tensorflow.keras import optimizers
+from tensorflow.keras.preprocessing.image import ImageDataGenerator
+from tensorflow.keras.layers import Dropout, Flatten, Dense, Activation
+from tensorflow.keras.callbacks import ReduceLROnPlateau, ModelCheckpoint
+from tensorflow.keras.models import Sequential
+from tensorflow.keras.layers import Conv2D
+from tensorflow.keras.layers import Activation, Dropout, Flatten, Dense
+from tensorflow.keras import backend as K
 
 # Disable PIL.PngImagePlugin DEBUG logs
 logging.config.dictConfig({

--- a/app/Detection/predict.py
+++ b/app/Detection/predict.py
@@ -6,9 +6,9 @@ import os
 import logging
 import argparse
 from tensorflow.keras.models import load_model
-from keras.preprocessing import image
+from tensorflow.keras.preprocessing import image
 import numpy as np
-from keras.preprocessing.image import img_to_array
+from tensorflow.keras.preprocessing.image import img_to_array
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
@@ -43,9 +43,11 @@ def predict(model_path, test_path):
 
     # stack up images list to pass for prediction
     # images = np.vstack(images)
-
-    classes = model.predict_classes(data, batch_size=32)
-
+    
+    # classes = model.predict_classes(data)
+    
+    classes = (model.predict(data) > 0.5).astype("int32")
+    
     f = []
     for i in os.listdir(folder_path):
         f.append(i)


### PR DESCRIPTION
Updated `import keras` to `import tensorflow.keras` and removed deprecated `model.predict_classes()` attribute